### PR TITLE
Update local cache after a fetch from remote cache

### DIFF
--- a/common_cache/__init__.py
+++ b/common_cache/__init__.py
@@ -700,6 +700,7 @@ class Cache(object):
                         cache_result = cache_loader(k)
                     elif self.cache_loader is not None:
                         cache_result = self.cache_loader(k)
+                        self.put(key=k, value=cache_result, expire=expire, timeout=timeout)
                 # if still miss then execute a function that is decorated
                 # then update cache on the basis of parameter auto_update
                 if cache_result is not None:


### PR DESCRIPTION
Update local cache after a fetch from remote cache.
This will help avoid multiple calls to remote cache for the same key that is being accessed continually too often. 
Correct me if I am wrong. 